### PR TITLE
Add additional features: --expires, --mimetype --verbose

### DIFF
--- a/bin/0x0
+++ b/bin/0x0
@@ -23,6 +23,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+API_ENDPOINT=https://0x0.st/
+
 if [[ -t 1 ]]; then
   # stdout is a TTY, enable colors
   STYLE_COMMAND="\033[0;97m"
@@ -49,7 +51,7 @@ print_error() {
 
 print_help() {
   base="${0##*/}"
-  echo -e "${STYLE_BOLD}0x0, a wrapper script for https://0x0.st/${STYLE_RESET}\n"
+  echo -e "${STYLE_BOLD}0x0, a wrapper script for ${API_ENDPOINT}${STYLE_RESET}\n"
   echo -e "  Upload a file:"
   echo -e "      ${STYLE_COMMAND}${base} ${STYLE_ARG}<file>${STYLE_RESET}\n"
   echo -e "  Upload from an URL (the file won't be fetched locally):"
@@ -73,11 +75,11 @@ esac
 
 if [[ -f "$1" || "$1" = '-' ]]; then
   # Upload from file or stdin
-  curl -F "file=@$1" https://0x0.st
+  curl -F "file=@$1" "$API_ENDPOINT"
 
 elif [[ "$1" =~ ^https?://.* ]]; then
   # Upload from URL
-  curl -F "url=$1" https://0x0.st
+  curl -F "url=$1" "$API_ENDPOINT"
 
 elif [[ -d "$1" ]]; then
   print_error "\"$1\" is a directory."

--- a/bin/0x0
+++ b/bin/0x0
@@ -24,6 +24,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 API_ENDPOINT=https://0x0.st/
+EXPIRES=0
+INPUT_ARG=""
 
 if [[ -t 1 ]]; then
   # stdout is a TTY, enable colors
@@ -52,6 +54,12 @@ print_error() {
 print_help() {
   base="${0##*/}"
   echo -e "${STYLE_BOLD}0x0, a wrapper script for ${API_ENDPOINT}${STYLE_RESET}\n"
+  echo -e "Usage: ${base} [options] <file|url>\n"
+  echo -e "Options:"
+  echo -e "  -e | --expires ${STYLE_ARG}<number>${STYLE_RESET}  Set an expiration on the file"
+  echo -e "                           'number' is the number of hours from now or"
+  echo -e "                           a timestamp in epoch milliseconds.\n"
+  echo -e "Examples:"
   echo -e "  Upload a file:"
   echo -e "      ${STYLE_COMMAND}${base} ${STYLE_ARG}<file>${STYLE_RESET}\n"
   echo -e "  Upload from an URL (the file won't be fetched locally):"
@@ -61,29 +69,61 @@ print_help() {
   echo -e "The uploaded file's URL is printed to standard output when the upload is completed."
 }
 
-case "${1:-}" in
-  # Exit with code 0 only if help was explicitly requested
-  -h|--help)
-    print_help
-    exit 0
-    ;;
-  '')
-    print_help
-    exit 1
-    ;;
-esac
+# Process options and arguments
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+  shift;
+  case "$opt" in
+    "-e"|"--expires")
+      if [[ $# -eq 0 ]] || [[ "$1" =~ ^-{1,2}.* ]]; then
+        print_error "Missing or invalid argument for expires option"
+      fi
+      EXPIRES="$1"
+      is_number='^[0-9]+$'
+      if ! [[ $EXPIRES =~ $is_number ]] ; then
+        print_error "Expires value must be a number"
+      fi
+      shift
+      ;;
+    "-h"|"--help")
+      print_help
+      exit 0
+      ;;
+    *)
+      INPUT_ARG="$opt"
+      ;;
+  esac
+done
 
-if [[ -f "$1" || "$1" = '-' ]]; then
+# Did we get an input argument?
+if [[ "$INPUT_ARG" == "" ]]; then
+  # No input argument
+  print_help
+  exit 1
+fi
+
+# Construct an array of opts for the curl command
+curl_opts=( "$API_ENDPOINT" )
+
+# Add expires to curl opts
+if [[ $EXPIRES -gt 0 ]]; then
+  curl_opts=( -F expires="$EXPIRES" "${curl_opts[@]}" )
+fi
+
+# Make appropriate curl opts from input
+if [[ -f "$INPUT_ARG" || "$INPUT_ARG" = '-' ]]; then
   # Upload from file or stdin
-  curl -F "file=@$1" "$API_ENDPOINT"
+  curl_opts=( -F file=@"$INPUT_ARG" "${curl_opts[@]}" )
 
-elif [[ "$1" =~ ^https?://.* ]]; then
+elif [[ "$INPUT_ARG" =~ ^https?://.* ]]; then
   # Upload from URL
-  curl -F "url=$1" "$API_ENDPOINT"
+  curl_opts=( -F url="$INPUT_ARG" "${curl_opts[@]}" )
 
-elif [[ -d "$1" ]]; then
-  print_error "\"$1\" is a directory."
+elif [[ -d "$INPUT_ARG" ]]; then
+  print_error "\"$INPUT_ARG\" is a directory."
 
 else
-  print_error "\"$1\": no such file."
+  print_error "\"$INPUT_ARG\": no such file."
 fi
+
+curl "${curl_opts[@]}"

--- a/bin/0x0
+++ b/bin/0x0
@@ -25,12 +25,12 @@ IFS=$'\n\t'
 
 if [[ -t 1 ]]; then
   # stdout is a TTY, enable colors
-  STYLE_COMMAND="\\e[0;97m"
-  STYLE_ARG="\\e[0;96m"
-  STYLE_ERROR="\\e[91m"
-  STYLE_BOLD="\\e[1m"
-  STYLE_NORMAL="\\e[22m"
-  STYLE_RESET="\\e[0m"
+  STYLE_COMMAND="\033[0;97m"
+  STYLE_ARG="\033[0;96m"
+  STYLE_ERROR="\033[91m"
+  STYLE_BOLD="\033[1m"
+  STYLE_NORMAL="\033[22m"
+  STYLE_RESET="\033[0m"
 else
   # stdout is not a TTY, disable colors
   STYLE_COMMAND=""
@@ -49,7 +49,7 @@ print_error() {
 
 print_help() {
   base="${0##*/}"
-	echo -e "${STYLE_BOLD}0x0, a wrapper script for https://0x0.st/${STYLE_RESET}\n"
+  echo -e "${STYLE_BOLD}0x0, a wrapper script for https://0x0.st/${STYLE_RESET}\n"
   echo -e "  Upload a file:"
   echo -e "      ${STYLE_COMMAND}${base} ${STYLE_ARG}<file>${STYLE_RESET}\n"
   echo -e "  Upload from an URL (the file won't be fetched locally):"

--- a/bin/0x0
+++ b/bin/0x0
@@ -26,6 +26,8 @@ IFS=$'\n\t'
 API_ENDPOINT=https://0x0.st/
 EXPIRES=0
 INPUT_ARG=""
+MIMETYPE=""
+VERBOSE=false
 
 if [[ -t 1 ]]; then
   # stdout is a TTY, enable colors
@@ -58,7 +60,11 @@ print_help() {
   echo -e "Options:"
   echo -e "  -e | --expires ${STYLE_ARG}<number>${STYLE_RESET}  Set an expiration on the file"
   echo -e "                           'number' is the number of hours from now or"
-  echo -e "                           a timestamp in epoch milliseconds.\n"
+  echo -e "                           a timestamp in epoch milliseconds."
+  echo -e "  -m | --mimetype ${STYLE_ARG}<type>${STYLE_RESET}   Force a mime-type to the uploaded content"
+  echo -e "                           example: -m text/plain"
+  echo -e "  -v | --verbose           Also return relevant headers from response"
+  echo -e "                           Outputs x-expires and x-token headers if present"
   echo -e "Examples:"
   echo -e "  Upload a file:"
   echo -e "      ${STYLE_COMMAND}${base} ${STYLE_ARG}<file>${STYLE_RESET}\n"
@@ -89,6 +95,15 @@ while [[ $# -gt 0 ]]; do
       print_help
       exit 0
       ;;
+    "-m"|"--mimetype")
+      if [[ $# -eq 0 ]] || [[ "$1" =~ ^-{1,2}.* ]]; then
+        print_error "Missing or invalid argument for mimetype option"
+      fi
+      MIMETYPE="$1"
+      ;;
+    "-v"|"--verbose")
+      VERBOSE=true
+      ;;
     *)
       INPUT_ARG="$opt"
       ;;
@@ -105,6 +120,12 @@ fi
 # Construct an array of opts for the curl command
 curl_opts=( "$API_ENDPOINT" )
 
+# Add support for verbose logic to curl command
+if [[ $VERBOSE == true ]]; then
+  tmp_file=$(mktemp)
+  curl_opts=( --no-progress-meter --dump-header "$tmp_file" "${curl_opts[@]}")
+fi
+
 # Add expires to curl opts
 if [[ $EXPIRES -gt 0 ]]; then
   curl_opts=( -F expires="$EXPIRES" "${curl_opts[@]}" )
@@ -113,6 +134,9 @@ fi
 # Make appropriate curl opts from input
 if [[ -f "$INPUT_ARG" || "$INPUT_ARG" = '-' ]]; then
   # Upload from file or stdin
+  if [[ $MIMETYPE != "" ]]; then
+    INPUT_ARG="$INPUT_ARG;type=$MIMETYPE"
+  fi
   curl_opts=( -F file=@"$INPUT_ARG" "${curl_opts[@]}" )
 
 elif [[ "$INPUT_ARG" =~ ^https?://.* ]]; then
@@ -127,3 +151,11 @@ else
 fi
 
 curl "${curl_opts[@]}"
+
+if [[ $VERBOSE == true ]]; then
+  echo -n -e "${STYLE_ARG}"
+  < "$tmp_file" grep -e x-expires -e x-token | cat
+  echo -n -e "${STYLE_RESET}"
+
+  rm -f "$tmp_file"
+fi


### PR DESCRIPTION
This makes a few updates to the 0x0 tool:

1) Supports setting the expires value when uploading a file, using `-e` or `--expires`
2) Supports the option `--verbose` (or `-v`) to show the expires value and token returned from the 0x0 service
3) Adds the setting `--mimetype` (or `-m`) to manually override the mime-type of the uploaded file

I refactored the logic to process the options and construct the curl command to support these features and dynamically create the curl command.